### PR TITLE
Remove the 5.1.0 docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ COPY . .
 
 COPY --from=index.docker.io/kicadeda/kicad-doc:4.0.7 /src /site/kicad-doc-built/4.0.7
 COPY --from=index.docker.io/kicadeda/kicad-doc:5.0.2 /src /site/kicad-doc-built/5.0.2
-COPY --from=index.docker.io/kicadeda/kicad-doc:5.1.0 /src /site/kicad-doc-built/5.1.0
 COPY --from=index.docker.io/kicadeda/kicad-doc:5.1.1 /src /site/kicad-doc-built/5.1.1
 COPY --from=index.docker.io/kicadeda/kicad-doc:master /src /site/kicad-doc-built/master
 

--- a/_source/_data/versions.yml
+++ b/_source/_data/versions.yml
@@ -7,9 +7,6 @@
 '5.0.2':
   label: 5.0.2
   default: false
-'5.1.0':
-  label: 5.1.0
-  default: false
 '5.1.1':
   label: 5.1.1
   default: true


### PR DESCRIPTION
This is done to limit the number of doc variations, as there are not
really that many changes and I don't see much gain is hosting all
versions.